### PR TITLE
chore: devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+ARG VARIANT=ubuntu-22.04
+FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PDK_ROOT=~/ttsetup/pdk
+ENV PDK=sky130A
+
+RUN apt update
+RUN apt install -y iverilog python3 python3-pip python3-venv python3-tk python-is-python3 libcairo2 verilator
+
+# Clone tt-support-tools
+RUN mkdir -p /ttsetup
+RUN git clone -b tt09 https://github.com/TinyTapeout/tt-support-tools /ttsetup/tt-support-tools
+
+COPY test/requirements.txt /ttsetup/test_requirements.txt
+COPY .devcontainer/copy_tt_support_tools.sh /ttsetup
+
+RUN pip3 install -r /ttsetup/test_requirements.txt -r /ttsetup/tt-support-tools/requirements.txt
+
+# Install verible (for formatting)
+RUN umask 022 && \
+    curl -L https://github.com/chipsalliance/verible/releases/download/v0.0-3795-gf4d72375/verible-v0.0-3795-gf4d72375-linux-static-x86_64.tar.gz | \
+    tar zxf - -C /usr/local --strip-components=1 && \
+    chmod 755 /usr/local/bin
+
+# Install openlane
+RUN pip3 install openlane==2.1.5

--- a/.devcontainer/copy_tt_support_tools.sh
+++ b/.devcontainer/copy_tt_support_tools.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+if [ ! -L tt ]; then
+    cp -R /ttsetup/tt-support-tools tt
+    cd tt && git pull && cd ..
+fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/ubuntu
+{
+  "name": "Tiny Tapeout Dev Container",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      },
+      "extensions": ["mshr-h.veriloghdl"]
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": true,
+      "azureDnsAutoDetection": true,
+      "version": "latest",
+      "dockerDashComposeVersion": "none"
+    }
+  },
+  "postStartCommand": "/ttsetup/copy_tt_support_tools.sh"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 .idea
-.vscode
 *.vcd
 runs
 tt_submission

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "mshr-h.veriloghdl"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "verilog.linting.linter": "verilator",
+  "verilog.formatting.verilogHDL.formatter": "verible-verilog-format"
+}


### PR DESCRIPTION
Set up dev container for local development:

1. Verilog syntax highlighting, linting and formatting set up in VS Code (using verilator and verible)
2. Cocotb 
3. Openlane2, tt-support-tools and all the required dependencies.