### PR TITLE
adding build dependencies and a minimum required memory amount

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@ ENV PDK_ROOT=~/ttsetup/pdk
 ENV PDK=sky130A
 
 RUN apt update
-RUN apt install -y iverilog python3 python3-pip python3-venv python3-tk python-is-python3 libcairo2 verilator
+RUN apt install -y iverilog python3 python3-pip python3-venv python3-tk python-is-python3 libcairo2 verilator libpng-dev libqhull-dev
 
 # Clone tt-support-tools
 RUN mkdir -p /ttsetup

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,10 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
+  "runArgs": [
+    "--cpus=4",
+    "--memory=10GB"
+  ],
   "customizations": {
     "vscode": {
       "settings": {


### PR DESCRIPTION
`libpng-dev` is required by klayout
`libqhull-dev` is required by gdstk

The klayout build consumes memory somewhat linearly with the number of cores the container has as the build will intelligently increase the number of compilers to fit how many cores are available, I saw 16GB memory use with 8 cores and 10 GB with 4 cores.

Happy to discuss alternative approaches. Hardcoding the number of cores and memory isn't my favorite but there's no way other than documentation to ensure a minimum amount of memory. devcontainers supports a `hostRequirement` config section but it's advisory and Docker (on macOS at least) completely ignores it and doesn't even issue a warning.

I tested this on macOS 14.6.1